### PR TITLE
Notification integration fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # Asana for Franz
 Asana recipe for Franz 5 !
+
+# Installation
+1. Open the Franz Plugins folder on your machine (note that this dev directory may not exist yet, and you must create it):
+  - Mac: ~/Library/Application Support/Franz/recipes/dev/
+  - Windows: %appdata%/Franz/recipes/dev/
+  - Linux: ~/.config/Franz/recipes/dev
+2. Copy the franz-recipe-asana folder into the plugins directory
+3. Reload Franz

--- a/webview.js
+++ b/webview.js
@@ -4,13 +4,10 @@ const path = require('path');
 
 module.exports = Franz => {
   const getMessages = function getMessages() {
-    const elements = document.querySelectorAll('.unread');
+    const hasNotification = document.querySelectorAll(".SidebarTopNavLinks-notificationsButton--hasNewNotifications");
     let count = 0;
-
-    for (let i = 0; i < elements.length; i += 1) {
-      if (elements[i].querySelectorAll('*[data-icon="muted"]').length === 0) {
-        count += 1;
-      }
+    if (hasNotification.length > 0) {
+      count +=1;
     }
 
     // set Franz badge


### PR DESCRIPTION
Fixed Franz notification integration.
Now it does not count unread messages from inbox, but it shows notification icon on all asana pages instead of only inbox page.
I think it's more useful in daily workflow.