### PR TITLE
Allow specifying organisation (as team)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "author": "Elnur Mammadov <baytbybayt@gmail.com>",
   "license": "MIT",
   "config": {
-    "serviceURL": "https://app.asana.com",
-    "hasNotificationSound": true
+    "serviceURL": "https://app.asana.com/0/home/{teamId}",
+    "hasNotificationSound": true,
+    "hasTeamId": true,
+    "urlInputPrefix": true
   }
 }


### PR DESCRIPTION
If you are a member of multiple organisations, this change allows you to choose the organisation you want to run asana with. With previous implementation you couldn't access any other organisation than the default one. 

If the teamID is left empty, asana automatically shows you your default organisation.